### PR TITLE
Feat upload photo

### DIFF
--- a/src/main/java/com/example/collab/controller/CollaboratorController.java
+++ b/src/main/java/com/example/collab/controller/CollaboratorController.java
@@ -2,13 +2,16 @@ package com.example.collab.controller;
 
 import java.util.List;
 
+import org.springframework.core.io.Resource;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.example.collab.domain.valueobject.document.CPF;
 import com.example.collab.dto.request.CollaboratorRequestDTO;
 import com.example.collab.dto.response.CollaboratorResponseDTO;
 import com.example.collab.service.CollaboratorService;
+import com.example.collab.service.PhotoStorageService;
 
 import jakarta.validation.Valid;
 
@@ -19,9 +22,13 @@ public class CollaboratorController {
     
     private CollaboratorService collaboratorService;
 
-    public CollaboratorController(CollaboratorService collaboratorService){
+    private PhotoStorageService photoStorageService;
+
+    public CollaboratorController(CollaboratorService collaboratorService, PhotoStorageService photoStorageService){
 
         this.collaboratorService = collaboratorService;
+
+        this.photoStorageService = photoStorageService;
         
     }
 
@@ -98,6 +105,37 @@ public class CollaboratorController {
 
     }
 
+    @PostMapping("/{registration}/photo")
+    public ResponseEntity<CollaboratorResponseDTO> uploadPhoto(@PathVariable Integer registration,
+            @RequestParam("photo") MultipartFile file) {
+
+        CollaboratorResponseDTO response = collaboratorService.uploadPhoto(registration, file);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+
+    }
+
+    @GetMapping("/{registration}/photo")
+    public ResponseEntity<Resource> getPhoto(@PathVariable Integer registration) {
+
+        CollaboratorResponseDTO collaborator = collaboratorService.getCollaboratorByRegistration(registration);
+
+        if (collaborator.photo() == null || collaborator.photo().isBlank()) {
+
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+
+        }
+
+        Resource resource = photoStorageService.loadPhoto(collaborator.photo());
+
+        String contentType = detectContentType(collaborator.photo());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .contentType(MediaType.parseMediaType(contentType))
+                .body(resource);
+
+    }
+
     @DeleteMapping("/{registration}")
     public ResponseEntity<String> deleteCollaborator(@PathVariable Integer registration) {
 
@@ -113,6 +151,26 @@ public class CollaboratorController {
         CPF response = collaboratorService.deleteCollaboratorByCPF(new CPF(cpf));
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(response);
+
+    }
+
+    private String detectContentType(String path) {
+
+        if (path.endsWith(".png")) {
+
+            return "image/png";
+
+        } else if (path.endsWith(".gif")) {
+
+            return "image/gif";
+
+        } else if (path.endsWith(".webp")) {
+
+            return "image/webp";
+
+        }
+
+        return "image/jpeg";
 
     }
 

--- a/src/main/java/com/example/collab/domain/converter/PhotoConverter.java
+++ b/src/main/java/com/example/collab/domain/converter/PhotoConverter.java
@@ -1,0 +1,24 @@
+package com.example.collab.domain.converter;
+
+import com.example.collab.domain.valueobject.Photo;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class PhotoConverter implements AttributeConverter<Photo, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Photo attribute) {
+
+        return attribute != null ? attribute.getPath() : null;
+
+    }
+
+    @Override
+    public Photo convertToEntityAttribute(String dbData) {
+
+        return dbData != null && !dbData.isBlank() ? new Photo(dbData) : null;
+
+    }
+}

--- a/src/main/java/com/example/collab/domain/model/Collaborator.java
+++ b/src/main/java/com/example/collab/domain/model/Collaborator.java
@@ -93,4 +93,7 @@ public class Collaborator {
     private String course;
 
     private String observations;
+
+    private Photo photo;
+    
 }

--- a/src/main/java/com/example/collab/domain/valueobject/Photo.java
+++ b/src/main/java/com/example/collab/domain/valueobject/Photo.java
@@ -1,0 +1,22 @@
+package com.example.collab.domain.valueobject;
+
+import com.example.collab.exception.business.InvalidDocumentException;
+
+import lombok.Value;
+
+@Value
+public class Photo {
+
+    String path;
+
+    public Photo(String path) {
+
+        if (path == null || path.isBlank()) {
+
+            throw new InvalidDocumentException("Photo path must be provided");
+
+        }
+
+        this.path = path;
+    }
+}

--- a/src/main/java/com/example/collab/dto/response/CollaboratorResponseDTO.java
+++ b/src/main/java/com/example/collab/dto/response/CollaboratorResponseDTO.java
@@ -77,6 +77,8 @@ public record CollaboratorResponseDTO (
 
     String course,
 
-    String observations
+    String observations,
+
+    String photo
 
 ) {};

--- a/src/main/java/com/example/collab/mapper/CollaboratorMapper.java
+++ b/src/main/java/com/example/collab/mapper/CollaboratorMapper.java
@@ -6,6 +6,7 @@ import com.example.collab.domain.valueobject.ContractType;
 import com.example.collab.domain.valueobject.banking.*;
 import com.example.collab.domain.valueobject.contact.*;
 import com.example.collab.domain.valueobject.document.*;
+import com.example.collab.domain.valueobject.Photo;
 import com.example.collab.domain.model.Collaborator;
 import com.example.collab.domain.model.Department;
 import com.example.collab.dto.request.CollaboratorRequestDTO;
@@ -70,6 +71,7 @@ public interface CollaboratorMapper {
     @Mapping(target = "RG", source = "RG", qualifiedByName = "fromRG")
     @Mapping(target = "phoneEmergency", source = "phoneEmergency", qualifiedByName = "fromPhoneEmergency")
     @Mapping(target = "department", source = "department", qualifiedByName = "fromDepartment")
+    @Mapping(target = "photo", source = "photo", qualifiedByName = "fromPhoto")
     @Mapping(target = "status", source = "status")
     CollaboratorResponseDTO toResponse(Collaborator collaborator);
 
@@ -294,6 +296,20 @@ public interface CollaboratorMapper {
     default String fromContractType(ContractType contractType) {
 
         return contractType != null ? contractType.getType() : null;
+
+    }
+
+    @Named("toPhoto")
+    default Photo toPhoto(String value) {
+
+        return value != null && !value.isBlank() ? new Photo(value) : null;
+
+    }
+
+    @Named("fromPhoto")
+    default String fromPhoto(Photo photo) {
+
+        return photo != null ? photo.getPath() : null;
 
     }
 

--- a/src/main/java/com/example/collab/service/CollaboratorService.java
+++ b/src/main/java/com/example/collab/service/CollaboratorService.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.example.collab.domain.model.Collaborator;
+import com.example.collab.domain.valueobject.Photo;
 import com.example.collab.domain.valueobject.document.*;
 import com.example.collab.domain.valueobject.banking.*;
 import com.example.collab.dto.request.CollaboratorRequestDTO;
@@ -29,15 +31,19 @@ public class CollaboratorService {
 
     private final DomainEventPublisher eventPublisher;
 
-    public CollaboratorService(CollaboratorRepository collaboratorRepository, CollaboratorValidator collaboratorValidator, CollaboratorMapper collaboratorMapper, DomainEventPublisher eventPublisher){
+    private final PhotoStorageService photoStorageService;
+
+    public CollaboratorService(CollaboratorRepository collaboratorRepository, CollaboratorValidator collaboratorValidator, CollaboratorMapper collaboratorMapper, DomainEventPublisher eventPublisher, PhotoStorageService photoStorageService){
         
         this.collaboratorRepository = collaboratorRepository;
         
         this.collaboratorValidator = collaboratorValidator;
-        
+
         this.collaboratorMapper = collaboratorMapper;
 
         this.eventPublisher = eventPublisher;
+
+        this.photoStorageService = photoStorageService;
 
     }
 
@@ -191,6 +197,32 @@ public class CollaboratorService {
         eventPublisher.publish("COLLABORATOR", aggregateId, "COLLABORATOR_DELETED", collaboratorMapper.toResponse(collaborator));
 
         return cpfValue;
+
+    }
+
+    @Transactional
+    public CollaboratorResponseDTO uploadPhoto(Integer registration, MultipartFile file) {
+
+        Collaborator collaborator = collaboratorRepository.findByRegistration(registration).orElseThrow(
+                () -> new BadRequestException("Collaborator not found with registration: " + registration));
+
+        if (collaborator.getPhoto() != null) {
+
+            photoStorageService.deletePhoto(collaborator.getPhoto().getPath());
+
+        }
+
+        String path = photoStorageService.savePhoto(file);
+
+        collaborator.setPhoto(new Photo(path));
+
+        Collaborator updatedCollaborator = collaboratorRepository.save(collaborator);
+
+        CollaboratorResponseDTO response = collaboratorMapper.toResponse(updatedCollaborator);
+
+        eventPublisher.publish("COLLABORATOR", updatedCollaborator.getId().toString(), "COLLABORATOR_UPDATED", response);
+
+        return response;
 
     }
 

--- a/src/main/java/com/example/collab/service/PhotoStorageService.java
+++ b/src/main/java/com/example/collab/service/PhotoStorageService.java
@@ -1,0 +1,158 @@
+package com.example.collab.service;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.example.collab.exception.business.BadRequestException;
+import com.example.collab.exception.resource.NotFoundException;
+
+import jakarta.annotation.PostConstruct;
+
+@Service
+public class PhotoStorageService {
+
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png", "gif", "webp");
+
+    @Value("${app.upload.path:uploads/photos}")
+    private String uploadPath;
+
+    private Path rootLocation;
+
+    @PostConstruct
+    public void init() {
+
+        this.rootLocation = Paths.get(uploadPath).toAbsolutePath().normalize();
+
+        try {
+
+            Files.createDirectories(rootLocation);
+
+        } catch (IOException e) {
+
+            throw new RuntimeException("Could not create upload directory: " + rootLocation, e);
+
+        }
+
+    }
+
+    public String savePhoto(MultipartFile file) {
+
+        if (file == null || file.isEmpty()) {
+
+            throw new BadRequestException("Photo file must not be empty");
+
+        }
+
+        String originalFilename = file.getOriginalFilename();
+
+        if (originalFilename == null || originalFilename.isBlank()) {
+
+            throw new BadRequestException("Photo file must have a name");
+
+        }
+
+        String extension = getExtension(originalFilename).toLowerCase();
+
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+
+            throw new BadRequestException("Invalid file type: " + extension + ". Allowed: " + ALLOWED_EXTENSIONS);
+
+        }
+
+        String newFilename = UUID.randomUUID() + "." + extension;
+
+        Path destination = rootLocation.resolve(newFilename).normalize();
+
+        if (!destination.startsWith(rootLocation)) {
+
+            throw new BadRequestException("Invalid file path");
+
+        }
+
+        try {
+
+            Files.copy(file.getInputStream(), destination, StandardCopyOption.REPLACE_EXISTING);
+
+        } catch (IOException e) {
+
+            throw new RuntimeException("Failed to store file: " + newFilename, e);
+
+        }
+
+        return newFilename;
+
+    }
+
+    public Resource loadPhoto(String path) {
+
+        try {
+
+            Path file = rootLocation.resolve(path).normalize();
+
+            Resource resource = new UrlResource(file.toUri());
+
+            if (resource.exists() && resource.isReadable()) {
+
+                return resource;
+
+            }
+
+            throw new NotFoundException("Photo not found: " + path);
+
+        } catch (MalformedURLException e) {
+
+            throw new NotFoundException("Photo not found: " + path);
+
+        }
+
+    }
+
+    public void deletePhoto(String path) {
+
+        if (path == null || path.isBlank()) {
+
+            return;
+
+        }
+
+        try {
+
+            Path file = rootLocation.resolve(path).normalize();
+
+            Files.deleteIfExists(file);
+
+        } catch (IOException e) {
+
+            throw new RuntimeException("Failed to delete file: " + path, e);
+
+        }
+
+    }
+
+    private String getExtension(String filename) {
+
+        int dotIndex = filename.lastIndexOf('.');
+
+        if (dotIndex == -1 || dotIndex == filename.length() - 1) {
+
+            throw new BadRequestException("File must have an extension");
+
+        }
+
+        return filename.substring(dotIndex + 1);
+
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,8 +46,15 @@ spring:
 
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 5MB
+      max-request-size: 10MB
 
 app:
+  upload:
+    path: ${UPLOAD_PATH:uploads/photos}
   jwt:
     secret: "${JWT_SECRET}"
     expiration-ms: ${JWT_EXPIRATION_MS}

--- a/src/test/java/com/example/collab/controller/CollaboratorControllerTest.java
+++ b/src/test/java/com/example/collab/controller/CollaboratorControllerTest.java
@@ -44,7 +44,7 @@ class CollaboratorControllerTest {
             1L, "John Doe", null, null, null, null, null, null, null,
             null, false, false, null, null, null, null, 12345,
             null, null, null, null, null, null, null, null, null, null,
-            null, null, null, null, null, null, null, null
+            null, null, null, null, null, null, null, null, null
         );
 
         when(collaboratorService.getAllCollaborators()).thenReturn(List.of(response));

--- a/src/test/java/com/example/collab/dto/response/CollaboratorResponseDTOTest.java
+++ b/src/test/java/com/example/collab/dto/response/CollaboratorResponseDTOTest.java
@@ -50,6 +50,7 @@ class CollaboratorResponseDTOTest {
             null,
             null,
             null,
+            null,
             null
         );
 

--- a/src/test/java/com/example/collab/service/CollaboratorServiceTest.java
+++ b/src/test/java/com/example/collab/service/CollaboratorServiceTest.java
@@ -124,6 +124,7 @@ class CollaboratorServiceTest {
             null,
             null,
             null,
+            null,
             null
         );
 
@@ -148,7 +149,7 @@ class CollaboratorServiceTest {
             1L, "John Doe", null, null, null, null, null, null, null,
             null, false, false, null, null, null, null, 12345, null,
             null, null, null, null, null, null, null, null, null, null,
-            null, null, null, null, null, null, null
+            null, null, null, null, null, null, null, null
         );
 
         when(collaboratorRepository.findByRegistration(12345)).thenReturn(Optional.of(collaborator));


### PR DESCRIPTION
Para o atendimento da issue #33 , esse PR foi desenvolvido.

**Solução Implantada**
Aqui fizemos uma função de salvar o filepath no banco e armazenar o arquivo na aplicação. Dessa forma, não sobrecarregamos o banco de dados com um volume gigantesco de informações e também mantemos uma configuração do que está ou não com fotos cadastradas.

**Envio**
Para enviar deve ser feito um POST na rota /collaborators/{registration}/photo com form data, no corpo deve conter o campo "photo" e o arquivo com a imagem.